### PR TITLE
Use package instead of dnf to install dnf-automatic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: install dnf-automatic package
-  dnf: name=dnf-automatic state=present
+  package: name=dnf-automatic state=present
 
 - name: deploy dnf-automatic configuration file
   template: src=automatic.conf.j2 dest=/etc/dnf/automatic.conf


### PR DESCRIPTION
Using package instead of the dnf module makes it possible to use this
role on CentOS 7 where dnf is not installed by default (using the dnf
package results in an error).