### PR TITLE
Feat reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,29 @@ This default configuration sets `dnf-automatic` up to automatically download and
 
 Note that the `dnf_automatic_base_overrides` dictionary can be used to override arbitrary preferences from the base dnf configuration file for `dnf-automatic`.
 
+In addition, `dnf_automatic_reboot` can be set to true to perform automatic reboots when installed updates require it:
+
+```yaml
+dnf_automatic_reboot: false
+dnf_automatic_reboot_time: "03:00"
+dnf_automatic_reboot_script: "/usr/local/sbin/reboot-when-needed.sh"
+dnf_automatic_reboot_script_mode: "0700"
+dnf_automatic_reboot_script_content: |
+  #!/bin/bash
+  /bin/needs-restarting -r || /sbin/reboot
+dnf_automatic_reboot_dependencies: yum-utils
+```
+
 Dependencies
 ------------
 
-No dependencies needed.
+This role has a dependency on `vlcty.systemd-timers` to periodically run the reboot script. It can be installed by adding the following block to roles/requirements.yml:
+
+```
+- src: https://github.com/vlcty/ansible-systemd-timers.git
+  name: vlcty.systemd-timers
+  scm: git
+```
 
 Example Playbook
 ----------------
@@ -55,6 +74,16 @@ This example playbook deploys `dnf-automatic` on all hosts but is configured suc
   roles:
   - { role: exploide.dnf-automatic, dnf_automatic_upgrade_type: default }
 ```
+
+This example playbook deploys `dnf-automatic` to install security updates only, and deploys additional timer to reboot at 4:00 am when required:
+
+```yaml
+- hosts: all
+  remote_user: root
+  roles:
+  - { role: exploide.dnf-automatic, dnf_automatic_reboot: true, dnf_automatic_reboot_time: "04:00" }
+```
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -43,25 +43,17 @@ In addition, `dnf_automatic_reboot` can be set to true to perform automatic rebo
 
 ```yaml
 dnf_automatic_reboot: false
-dnf_automatic_reboot_time: "03:00"
-dnf_automatic_reboot_script: "/usr/local/sbin/reboot-when-needed.sh"
-dnf_automatic_reboot_script_mode: "0700"
-dnf_automatic_reboot_script_content: |
-  #!/bin/bash
-  /bin/needs-restarting -r || /sbin/reboot
 dnf_automatic_reboot_dependencies: yum-utils
+dnf_automatic_reboot_OnCalendar: "03:00"
+dnf_automatic_reboot_AccuracySec: "15s"
+dnf_automatic_reboot_Description: "dnf-automatic-reboot"
+dnf_automatic_reboot_ExecStart: /bin/bash -c '/bin/needs-restarting -r || /sbin/reboot'
 ```
 
 Dependencies
 ------------
 
-This role has a dependency on `vlcty.systemd-timers` to periodically run the reboot script. It can be installed by adding the following block to roles/requirements.yml:
-
-```
-- src: https://github.com/vlcty/ansible-systemd-timers.git
-  name: vlcty.systemd-timers
-  scm: git
-```
+No dependencies needed.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,14 @@ dnf_automatic_email_host: localhost
 
 # this dict can be used to override arbitrary settings from dnf.conf
 dnf_automatic_base_overrides: {}
+
+# Reboot
+
+dnf_automatic_reboot: false
+dnf_automatic_reboot_time: "03:00"
+dnf_automatic_reboot_script: "/usr/local/sbin/reboot-when-needed.sh"
+dnf_automatic_reboot_script_mode: "0700"
+dnf_automatic_reboot_script_content: |
+  #!/bin/bash
+  /bin/needs-restarting -r || /sbin/reboot
+dnf_automatic_reboot_dependencies: yum-utils

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,10 +39,8 @@ dnf_automatic_base_overrides: {}
 # Reboot
 
 dnf_automatic_reboot: false
-dnf_automatic_reboot_time: "03:00"
-dnf_automatic_reboot_script: "/usr/local/sbin/reboot-when-needed.sh"
-dnf_automatic_reboot_script_mode: "0700"
-dnf_automatic_reboot_script_content: |
-  #!/bin/bash
-  /bin/needs-restarting -r || /sbin/reboot
 dnf_automatic_reboot_dependencies: yum-utils
+dnf_automatic_reboot_OnCalendar: "03:00"
+dnf_automatic_reboot_AccuracySec: "15s"
+dnf_automatic_reboot_Description: "dnf-automatic-reboot"
+dnf_automatic_reboot_ExecStart: /bin/bash -c '/bin/needs-restarting -r || /sbin/reboot'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
     - name: EL
       versions:
       - 7
+      - 8
     - name: Fedora
       versions:
       - all

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,10 @@ galaxy_info:
     - packaging
     - system
 
-dependencies: []
+dependencies:
+  - role: vlcty.systemd-timers
+    timers:
+      dnf-automatic-reboot:
+        timer_command: "{{ dnf_automatic_reboot_script }}"
+        timer_OnCalendar: "{{ dnf_automatic_reboot_time }}"
+    when: dnf_automatic_reboot

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,10 +20,4 @@ galaxy_info:
     - packaging
     - system
 
-dependencies:
-  - role: vlcty.systemd-timers
-    timers:
-      dnf-automatic-reboot:
-        timer_command: "{{ dnf_automatic_reboot_script }}"
-        timer_OnCalendar: "{{ dnf_automatic_reboot_time }}"
-    when: dnf_automatic_reboot
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,16 @@
     name: dnf-automatic-install.timer
     state: started
     enabled: yes
+
+- name: Install dependencies needed for reboot
+  package:
+    name: "{{ dnf_automatic_reboot_dependencies }}"
+    state: present
+  when: dnf_automatic_reboot|bool
+
+- name: Copy reboot script
+  copy:
+    dest: "{{ dnf_automatic_reboot_script }}"
+    content: "{{ dnf_automatic_reboot_script_content }}"
+    mode: "{{ dnf_automatic_reboot_script_mode }}"
+  when: dnf_automatic_reboot|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,15 +16,31 @@
     state: started
     enabled: yes
 
-- name: Install dependencies needed for reboot
-  package:
-    name: "{{ dnf_automatic_reboot_dependencies }}"
-    state: present
+- block:
+
+  - name: Install dependencies needed for reboot
+    package:
+      name: "{{ dnf_automatic_reboot_dependencies }}"
+      state: present
+    tags: pkg
+
+  - name: Deploy service and timer units
+    template:
+      src: "{{ item }}"
+      dest: "/etc/systemd/system/{{ item }}"
+      owner: root
+      group: root
+      mode: 0640
+    loop:
+      - dnf-automatic-reboot.service
+      - dnf-automatic-reboot.timer
+
   when: dnf_automatic_reboot|bool
 
-- name: Copy reboot script
-  copy:
-    dest: "{{ dnf_automatic_reboot_script }}"
-    content: "{{ dnf_automatic_reboot_script_content }}"
-    mode: "{{ dnf_automatic_reboot_script_mode }}"
-  when: dnf_automatic_reboot|bool
+- name: Set timer state for auto reboot
+  systemd:
+    name: dnf-automatic-reboot.timer
+    state: "{{ dnf_automatic_reboot | ternary ('started', 'stopped') }}"
+    enabled: "{{ dnf_automatic_reboot }}"
+    masked: false
+    daemon_reload: true

--- a/templates/dnf-automatic-reboot.service
+++ b/templates/dnf-automatic-reboot.service
@@ -1,0 +1,8 @@
+# Managed by ansible - role dnf-automatic
+
+[Unit]
+Description={{ dnf_automatic_reboot_Description }} service
+
+[Service]
+Type=oneshot
+ExecStart={{ dnf_automatic_reboot_ExecStart }}

--- a/templates/dnf-automatic-reboot.timer
+++ b/templates/dnf-automatic-reboot.timer
@@ -1,0 +1,11 @@
+# Managed by ansible - role dnf-automatic
+
+[Unit]
+Description={{ dnf_automatic_reboot_Description }} timer
+
+[Timer]
+OnCalendar={{ dnf_automatic_reboot_OnCalendar }}
+AccuracySec={{ dnf_automatic_reboot_AccuracySec }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Hi,

Unfortunately dnf-automatic doesn't offer to reboot hosts when installed updates require it. This PR extends the role to handle this by installing the "needs-restarting" command, and install a script that will trigger the reboot only when needed. The script is periodically called by a systemd-timer, deployed using the role [vlcty.systemd-timers](https://github.com/vlcty/ansible-systemd-timers).

It has been successfully deployed on RHEL 8 so far.