### PR TITLE
Support running the role in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,12 +10,6 @@
     src: automatic.conf.j2
     dest: /etc/dnf/automatic.conf
 
-- name: Start and enable systemd timer for dnf-automatic
-  service:
-    name: dnf-automatic-install.timer
-    state: started
-    enabled: yes
-
 - name: Install dependencies needed for reboot
   package:
     name: "{{ dnf_automatic_reboot_dependencies }}"
@@ -35,6 +29,13 @@
 
 - name: Populate service facts
   service_facts:
+
+- name: Start and enable systemd timer for dnf-automatic
+  service:
+    name: dnf-automatic-install.timer
+    state: started
+    enabled: yes
+  when: ansible_facts.services['dnf-automatic-install.timer'] is defined
 
 - name: Set timer state for auto reboot
   systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,22 +10,26 @@
     src: automatic.conf.j2
     dest: /etc/dnf/automatic.conf
 
-- name: Install dependencies needed for reboot
-  package:
-    name: "{{ dnf_automatic_reboot_dependencies }}"
-    state: present
-  when: dnf_automatic_reboot|bool
+- block:
 
-- name: Deploy service and timer units
-  template:
-    src: "{{ item }}"
-    dest: "/etc/systemd/system/{{ item }}"
-    owner: root
-    group: root
-    mode: 0640
-  loop:
-    - dnf-automatic-reboot.service
-    - dnf-automatic-reboot.timer
+  - name: Install dependencies needed for reboot
+    package:
+      name: "{{ dnf_automatic_reboot_dependencies }}"
+      state: present
+    tags: pkg
+
+  - name: Deploy service and timer units
+    template:
+      src: "{{ item }}"
+      dest: "/etc/systemd/system/{{ item }}"
+      owner: root
+      group: root
+      mode: 0640
+    loop:
+      - dnf-automatic-reboot.service
+      - dnf-automatic-reboot.timer
+
+  when: dnf_automatic_reboot|bool
 
 - name: Populate service facts
   service_facts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,9 @@
     - dnf-automatic-reboot.service
     - dnf-automatic-reboot.timer
 
+- name: Populate service facts
+  service_facts:
+
 - name: Set timer state for auto reboot
   systemd:
     name: dnf-automatic-reboot.timer
@@ -40,3 +43,4 @@
     enabled: "{{ dnf_automatic_reboot }}"
     masked: false
     daemon_reload: true
+  when: ansible_facts.services['dnf-automatic-reboot.timer'] is defined


### PR DESCRIPTION
First of all, thanks for a nice and simple `dnf-automatic` Ansible role.

I decided to use your role for one of my projects and ran into issues while running a playbook that used the role in check mode first. I realized that the role was making reasonable assumptions about systemd units existing on the host, but this didn't work well in check mode.

My PR proposes two main changes:
- Gater `service_facts` after all tasks that may modify systemd unit files on the host have been executed. Move all tasks which modify the state of systemd units after `service_facts` have been gathered and execute them only if respective unit files exist on the host.
- Since the previous change fixed the problem fixed by 6a1d1e009874a2df10ba4f94eaf2306c1f86029e, I propose to revert it. The reason is that I don't like that unused systemd unit files get deployed on the host. In addition, the service file chat handles the actual auto reboot would not work anyway without the `yum_utils` not being installed (which it is not if the auto reboot is disabled).

Additional details are in each commit message.

I'll be happy to rework the PR if you have better ideas or don't like something about it 😉 