### PR TITLE
Fix setting state of timer units and enable GH actions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+---
+skip_list:
+  # the role name does not follow galaxy requirements
+  # https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names
+  - role-name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  ansible-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+
+      - name: Run ansible-lint
+        uses: ansible-community/ansible-lint-action@main
+        with:
+          path: "${{ github.repository }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,5 +75,5 @@ jobs:
           export tag="${{ matrix.image.tag }}"
           export PY_COLORS=1
           export ANSIBLE_FORCE_COLOR=1
-          molecule --debug test -s "${{ matrix.scenario }}"
+          molecule test -s "${{ matrix.scenario }}"
         working-directory: "${{ github.repository }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,58 @@ jobs:
         uses: ansible-community/ansible-lint-action@main
         with:
           path: "${{ github.repository }}"
+
+  test:
+    needs:
+      - ansible-lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: "centos"
+            namespace: "quay.io/centos"
+            tag: "stream8"
+          - name: "centos"
+            namespace: "quay.io/centos"
+            tag: "stream9"
+          - name: "fedora"
+            namespace: "quay.io/fedora"
+            tag: "latest"
+        scenario:
+          - default
+          - auto_reboot
+    container:
+      image: "quay.io/fedora/fedora:latest"
+      # --cgroupns=host needed due to https://github.com/containers/podman/discussions/12898#discussioncomment-4078154
+      options: "--privileged --volume /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host"
+      env:
+        HOME: "/root"
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+
+      - name: install dependencies
+        run: |
+          dnf install -y podman \
+            which \
+            python3-molecule \
+            python3-click-help-colors \
+            python3-rich \
+            python3-enrich \
+            python3-pluggy \
+            python3-cookiecutter
+
+      - name: run molecule
+        run: |
+          export HOME="/root"
+          export image="${{ matrix.image.name }}"
+          export namespace="${{ matrix.image.namespace }}"
+          export tag="${{ matrix.image.tag }}"
+          export PY_COLORS=1
+          export ANSIBLE_FORCE_COLOR=1
+          molecule --debug test -s "${{ matrix.scenario }}"
+        working-directory: "${{ github.repository }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/molecule/auto_reboot/Dockerfile.j2
+++ b/molecule/auto_reboot/Dockerfile.j2
@@ -1,0 +1,30 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container=docker
+
+RUN dnf -y install systemd && dnf clean all && \
+    systemctl mask systemd-remount-fs.service \
+                   dev-hugepages.mount \
+                   sys-fs-fuse-connections.mount \
+                   systemd-logind.service \
+                   getty.target \
+                   console-getty.service && \
+    systemctl disable dnf-makecache.timer \
+                      dnf-makecache.service
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/auto_reboot/converge.yml
+++ b/molecule/auto_reboot/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - name: "Include ansible-role-dnf-automatic"
+      ansible.builtin.include_role:
+        name: "ansible-role-dnf-automatic"
+      vars:
+        dnf_automatic_reboot: true

--- a/molecule/auto_reboot/molecule.yml
+++ b/molecule/auto_reboot/molecule.yml
@@ -1,0 +1,18 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: "dnf-automatic-${image:-fedora}-${tag:-latest}"
+    image: "${namespace:-quay.io/fedora}/${image:-fedora}:${tag:-latest}"
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: false
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/auto_reboot/verify.yml
+++ b/molecule/auto_reboot/verify.yml
@@ -1,0 +1,74 @@
+---
+- name: Verify scenario with auto reboot enabled
+  hosts: all
+
+  tasks:
+  # test packages
+  - name: Gather package facts
+    ansible.builtin.package_facts:
+      manager: auto
+
+  - name: Check that dnf-automatic is installed
+    ansible.builtin.assert:
+      that:
+        - ansible_facts.packages['dnf-automatic'] is defined
+
+  - name: Define auto reboot dependency package name
+    ansible.builtin.set_fact:
+      auto_reboot_dependency_package: "{{ 'yum-utils' if ansible_distribution != 'Fedora' else 'dnf-utils' }}"
+
+  - name: Check that auto reboot dependency package is installed
+    ansible.builtin.assert:
+      that:
+        - ansible_facts.packages[auto_reboot_dependency_package] is defined
+
+  # test dnf-automatic configuration
+  - name: Fetch /etc/dnf/automatic.conf from remote host and register it as automatic_conf
+    ansible.builtin.fetch:
+      src: /etc/dnf/automatic.conf
+      dest: /tmp/
+      flat: true
+    register: automatic_conf
+
+  - name: Check content of /etc/dnf/automatic.conf
+    ansible.builtin.assert:
+      that:
+        - "'Ansible' in lookup('file', '/tmp/automatic.conf')"
+        - "'apply_updates = True' in lookup('file', '/tmp/automatic.conf')"
+        - "'download_updates = True' in lookup('file', '/tmp/automatic.conf')"
+        - "'upgrade_type = security' in lookup('file', '/tmp/automatic.conf')"
+
+  # test systemd units
+  - name: Check status of dnf-automatic-install.timer
+    ansible.builtin.systemd:
+      name: dnf-automatic-install.timer
+    register: dnf_automatic_install_timer
+
+  - name: Check that dnf-automatic-install.timer is started and enabled
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_install_timer.status['LoadState'] == 'loaded'
+        - dnf_automatic_install_timer.status['ActiveState'] == 'active'
+        - dnf_automatic_install_timer.status['UnitFileState'] == 'enabled'
+
+  - name: Check status of dnf-automatic-reboot.timer
+    ansible.builtin.systemd:
+      name: dnf-automatic-reboot.timer
+    register: dnf_automatic_reboot_timer
+
+  - name: Check that dnf-automatic-reboot.timer is started and enabled
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_reboot_timer.status['LoadState'] == 'loaded'
+        - dnf_automatic_reboot_timer.status['ActiveState'] == 'active'
+        - dnf_automatic_reboot_timer.status['UnitFileState'] == 'enabled'
+
+  - name: Check status of dnf-automatic-reboot.service
+    ansible.builtin.systemd:
+      name: dnf-automatic-reboot.service
+    register: dnf_automatic_reboot_service
+
+  - name: Check that dnf-automatic-reboot.service exists
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_reboot_service.status['LoadState'] == 'loaded'

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,30 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container=docker
+
+RUN dnf -y install systemd && dnf clean all && \
+    systemctl mask systemd-remount-fs.service \
+                   dev-hugepages.mount \
+                   sys-fs-fuse-connections.mount \
+                   systemd-logind.service \
+                   getty.target \
+                   console-getty.service && \
+    systemctl disable dnf-makecache.timer \
+                      dnf-makecache.service
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - name: "Include ansible-role-dnf-automatic"
+      ansible.builtin.include_role:
+        name: "ansible-role-dnf-automatic"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: "dnf-automatic-${image:-fedora}-${tag:-latest}"
+    image: "${namespace:-quay.io/fedora}/${image:-fedora}:${tag:-latest}"
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: false
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,69 @@
+---
+- name: Verify default scenario
+  hosts: all
+
+  tasks:
+  # test packages
+  - name: Gather package facts
+    ansible.builtin.package_facts:
+      manager: auto
+
+  - name: Check that dnf-automatic is installed
+    ansible.builtin.assert:
+      that:
+        - ansible_facts.packages['dnf-automatic'] is defined
+
+  - name: Check that yum-utils are not installed
+    ansible.builtin.assert:
+      that:
+        - ansible_facts.packages['yum-utils'] is not defined
+
+  # test dnf-automatic configuration
+  - name: Fetch /etc/dnf/automatic.conf from remote host and register it as automatic_conf
+    ansible.builtin.fetch:
+      src: /etc/dnf/automatic.conf
+      dest: /tmp/
+      flat: true
+
+  - name: Check content of /etc/dnf/automatic.conf
+    ansible.builtin.assert:
+      that:
+        - "'Ansible' in lookup('file', '/tmp/automatic.conf')"
+        - "'apply_updates = True' in lookup('file', '/tmp/automatic.conf')"
+        - "'download_updates = True' in lookup('file', '/tmp/automatic.conf')"
+        - "'upgrade_type = security' in lookup('file', '/tmp/automatic.conf')"
+
+  # test systemd units
+  - name: Check status of dnf-automatic-install.timer
+    ansible.builtin.systemd:
+      name: dnf-automatic-install.timer
+    register: dnf_automatic_install_timer
+
+  - name: Check that dnf-automatic-install.timer is started and enabled
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_install_timer.status['LoadState'] == 'loaded'
+        - dnf_automatic_install_timer.status['ActiveState'] == 'active'
+        - dnf_automatic_install_timer.status['UnitFileState'] == 'enabled'
+
+  - name: Check status of dnf-automatic-reboot.timer
+    ansible.builtin.systemd:
+      name: dnf-automatic-reboot.timer
+    register: dnf_automatic_reboot_timer
+
+  - name: Check that dnf-automatic-reboot.timer does not exist
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_reboot_timer.status['LoadState'] == 'not-found'
+        - dnf_automatic_reboot_timer.status['ActiveState'] == 'inactive'
+
+  - name: Check status of dnf-automatic-reboot.service
+    ansible.builtin.systemd:
+      name: dnf-automatic-reboot.service
+    register: dnf_automatic_reboot_service
+
+  - name: Check that dnf-automatic-reboot.service does not exist
+    ansible.builtin.assert:
+      that:
+        - dnf_automatic_reboot_service.status['LoadState'] == 'not-found'
+        - dnf_automatic_reboot_service.status['ActiveState'] == 'inactive'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,16 +29,27 @@
       loop:
         - dnf-automatic-reboot.service
         - dnf-automatic-reboot.timer
+      notify: Reload systemd
 
-- name: Populate service facts
-  ansible.builtin.service_facts:
+- name: Check status of dnf-automatic-install.timer
+  ansible.builtin.systemd:
+    name: dnf-automatic-install.timer
+  register: dnf_automatic_install_timer
 
 - name: Start and enable systemd timer for dnf-automatic
   ansible.builtin.service:
     name: dnf-automatic-install.timer
     state: started
     enabled: true
-  when: ansible_facts.services['dnf-automatic-install.timer'] is defined
+  # run always if not in check mode or if the timer unit exists
+  # regardless of the check mode state
+  when: not ansible_check_mode or
+        dnf_automatic_install_timer.status["LoadState"] == "loaded"
+
+- name: Check status of dnf-automatic-reboot.timer
+  ansible.builtin.systemd:
+    name: dnf-automatic-reboot.timer
+  register: dnf_automatic_reboot_timer
 
 - name: Set timer state for auto reboot
   ansible.builtin.systemd:
@@ -46,5 +57,7 @@
     state: "{{ dnf_automatic_reboot | ternary('started', 'stopped') }}"
     enabled: "{{ dnf_automatic_reboot }}"
     masked: false
-    daemon_reload: true
-  when: ansible_facts.services['dnf-automatic-reboot.timer'] is defined
+  # run always if not in check mode and the auto reboot is enabled
+  # or if the timer unit exists regardless of the check mode state
+  when: (not ansible_check_mode and dnf_automatic_reboot) or
+        dnf_automatic_reboot_timer.status["LoadState"] == "loaded"


### PR DESCRIPTION
Changes merged in PR#6 [1] made the tasks setting state of
`dnf-automatic-install.timer` and `dnf-automatic-reboot.timer` to be
always skipped. The reason is that `service_facts` contain status only
of `.service` units. This means that no `.timer` unit will be ever
listed in `service_facts`, even if it exists.

Change the implementation to use systemd module to check status of the
respective `.timer` units and act based on that information.

Also amend the conditions when these task are executed. Now they are
executed if in check_mode and a potentially necessary other condition is
met (such as enabled auto reboot) and regardless of the check_mode if
the `.timer` unit exists on the system.

Enable linting in GH actions.

I also wrote molecule tests in https://github.com/exploide/ansible-role-dnf-automatic/commit/de18578a70e8fe0b009819180f91852ca14e481b but [could not get it to work in GH actions so far](https://github.com/thozza/ansible-role-dnf-automatic/pull/1), although it works when run locally on Fedora using `podman`

Sorry again for the previously introduced issue 🙄 