### PR TITLE
Chore: Add support for new timer name in dnf5

### DIFF
--- a/tasks/dnf4.yml
+++ b/tasks/dnf4.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Install dnf-automatic package
+  ansible.builtin.package:
+    name: dnf-automatic
+    state: present
+
+- name: Deploy dnf-automatic configuration file
+  ansible.builtin.template:
+    src: automatic.conf.j2
+    dest: /etc/dnf/automatic.conf
+    mode: "0644"
+
+- name: Perform auto reboot specific tasks
+  when: dnf_automatic_reboot | bool
+  block:
+    - name: Install dependencies needed for reboot
+      ansible.builtin.package:
+        name: "{{ dnf_automatic_reboot_dependencies }}"
+        state: present
+
+    - name: Deploy service and timer units
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: "/etc/systemd/system/{{ item }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - dnf-automatic-reboot.service
+        - dnf-automatic-reboot.timer
+      notify: Reload systemd
+
+- name: Check status of dnf-automatic-install.timer
+  ansible.builtin.systemd:
+    name: dnf-automatic-install.timer
+  register: dnf_automatic_install_timer
+
+- name: Start and enable systemd timer for dnf-automatic
+  ansible.builtin.service:
+    name: dnf-automatic-install.timer
+    state: started
+    enabled: true
+  # run always if not in check mode or if the timer unit exists
+  # regardless of the check mode state
+  when: not ansible_check_mode or
+        dnf_automatic_install_timer.status["LoadState"] == "loaded"
+
+- name: Check status of dnf-automatic-reboot.timer
+  ansible.builtin.systemd:
+    name: dnf-automatic-reboot.timer
+  register: dnf_automatic_reboot_timer
+
+- name: Set timer state for auto reboot
+  ansible.builtin.systemd:
+    name: dnf-automatic-reboot.timer
+    state: "{{ dnf_automatic_reboot | ternary('started', 'stopped') }}"
+    enabled: "{{ dnf_automatic_reboot }}"
+    masked: false
+  # run always if not in check mode and the auto reboot is enabled
+  # or if the timer unit exists regardless of the check mode state
+  when: (not ansible_check_mode and dnf_automatic_reboot) or
+        dnf_automatic_reboot_timer.status["LoadState"] == "loaded"

--- a/tasks/dnf5.yml
+++ b/tasks/dnf5.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Install dnf-automatic package
+  ansible.builtin.package:
+    name: dnf5-plugin-automatic
+    state: present
+
+- name: Deploy dnf-automatic configuration file
+  ansible.builtin.template:
+    src: automatic.conf.j2
+    dest: /etc/dnf/automatic.conf
+    mode: "0644"
+
+- name: Perform auto reboot specific tasks
+  when: dnf_automatic_reboot | bool
+  block:
+    - name: Install dependencies needed for reboot
+      ansible.builtin.package:
+        name: "{{ dnf_automatic_reboot_dependencies }}"
+        state: present
+
+    - name: Deploy service and timer units
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: "/etc/systemd/system/{{ item }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - dnf-automatic-reboot.service
+        - dnf-automatic-reboot.timer
+      notify: Reload systemd
+
+- name: Check status of dnf-automatic-download.timer
+  ansible.builtin.systemd:
+    name: dnf5-automatic.timer
+  register: dnf_automatic_timer
+
+- name: Start and enable systemd timer for dnf-automatic
+  ansible.builtin.service:
+    name: dnf5-automatic.timer
+    state: started
+    enabled: true
+  # run always if not in check mode or if the timer unit exists
+  # regardless of the check mode state
+  when: not ansible_check_mode or
+        dnf_automatic_timer.status["LoadState"] == "loaded"
+
+- name: Check status of dnf-automatic-reboot.timer
+  ansible.builtin.systemd:
+    name: dnf-automatic-reboot.timer
+  register: dnf_automatic_reboot_timer
+
+- name: Set timer state for auto reboot
+  ansible.builtin.systemd:
+    name: dnf-automatic-reboot.timer
+    state: "{{ dnf_automatic_reboot | ternary('started', 'stopped') }}"
+    enabled: "{{ dnf_automatic_reboot }}"
+    masked: false
+  # run always if not in check mode and the auto reboot is enabled
+  # or if the timer unit exists regardless of the check mode state
+  when: (not ansible_check_mode and dnf_automatic_reboot) or
+        dnf_automatic_reboot_timer.status["LoadState"] == "loaded"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,63 +1,19 @@
 ---
+# manage dnf bases on the distribution
 
-- name: Install dnf-automatic package
-  ansible.builtin.package:
-    name: dnf-automatic
-    state: present
+- name: Manage dnf automatic version 4 for centos8
+  import_tasks: dnf4.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution == "CentOS" and ansible_distribution_major_version | int <= 8
 
-- name: Deploy dnf-automatic configuration file
-  ansible.builtin.template:
-    src: automatic.conf.j2
-    dest: /etc/dnf/automatic.conf
-    mode: "0644"
+- name: Manage dnf automatic version 4 for centos9
+  import_tasks: dnf4.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 9
 
-- name: Perform auto reboot specific tasks
-  when: dnf_automatic_reboot | bool
-  block:
-    - name: Install dependencies needed for reboot
-      ansible.builtin.package:
-        name: "{{ dnf_automatic_reboot_dependencies }}"
-        state: present
+- name: Manage dnf automatic version 5 for fedora40
+  import_tasks: dnf4.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution == "Fedora" and ansible_distribution_major_version | int == 40
 
-    - name: Deploy service and timer units
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: "/etc/systemd/system/{{ item }}"
-        owner: root
-        group: root
-        mode: "0644"
-      loop:
-        - dnf-automatic-reboot.service
-        - dnf-automatic-reboot.timer
-      notify: Reload systemd
+- name: Manage dnf automatic version 5 for fedora41
+  import_tasks: dnf5.yml
+  when: ansible_os_family == 'RedHat' and ansible_distribution == "Fedora" and ansible_distribution_major_version | int >= 41
 
-- name: Check status of dnf-automatic-install.timer
-  ansible.builtin.systemd:
-    name: dnf-automatic-install.timer
-  register: dnf_automatic_install_timer
-
-- name: Start and enable systemd timer for dnf-automatic
-  ansible.builtin.service:
-    name: dnf-automatic-install.timer
-    state: started
-    enabled: true
-  # run always if not in check mode or if the timer unit exists
-  # regardless of the check mode state
-  when: not ansible_check_mode or
-        dnf_automatic_install_timer.status["LoadState"] == "loaded"
-
-- name: Check status of dnf-automatic-reboot.timer
-  ansible.builtin.systemd:
-    name: dnf-automatic-reboot.timer
-  register: dnf_automatic_reboot_timer
-
-- name: Set timer state for auto reboot
-  ansible.builtin.systemd:
-    name: dnf-automatic-reboot.timer
-    state: "{{ dnf_automatic_reboot | ternary('started', 'stopped') }}"
-    enabled: "{{ dnf_automatic_reboot }}"
-    masked: false
-  # run always if not in check mode and the auto reboot is enabled
-  # or if the timer unit exists regardless of the check mode state
-  when: (not ansible_check_mode and dnf_automatic_reboot) or
-        dnf_automatic_reboot_timer.status["LoadState"] == "loaded"


### PR DESCRIPTION
Thank you for this role.  I've been using it on CentOS7, 8, 9 and Fedora 40, 41.

This role began throwing errors when trying to manage a Fedora41 system which introduced dnf5.  This changed the package name for dnf-automatic and the timer name.
This commit introduces logic to test for distribution and then apply appropriate dnf config.