### PR TITLE
Use dnf-automatic.timer to always follow configuration.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Set DNF4 variables
   ansible.builtin.set_fact:
     dnf_automatic_package_name: dnf-automatic
-    dnf_automatic_systemd_timer: dnf-automatic-install.timer
+    dnf_automatic_systemd_timer: dnf-automatic.timer
   when: ansible_facts["pkg_mgr"] == "dnf4" or ansible_facts["pkg_mgr"] == "dnf"
 
 - name: Set DNF5 variables
@@ -68,7 +68,7 @@
 - name: "Check status of {{ dnf_automatic_systemd_timer }}"
   ansible.builtin.systemd:
     name: "{{ dnf_automatic_systemd_timer }}"
-  register: dnf_automatic_install_timer
+  register: dnf_automatic_timer_status
 
 - name: Start and enable systemd timer for dnf-automatic
   ansible.builtin.service:
@@ -78,7 +78,7 @@
   # run always if not in check mode or if the timer unit exists
   # regardless of the check mode state
   when: not ansible_check_mode or
-        dnf_automatic_install_timer.status["LoadState"] == "loaded"
+        dnf_automatic_timer_status.status["LoadState"] == "loaded"
 
 - name: Check status of dnf-automatic-reboot.timer
   ansible.builtin.systemd:


### PR DESCRIPTION
Issue: `dnf-automatic-install.timer` overrides the `dnf_automatic_download_updates: false` and `dnf_automatic_apply_updates: false` configuration setting and will always download and install packages.