### PR TITLE
task: Remove host dependant variable from task name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     dnf_automatic_systemd_timer: dnf5-automatic.timer
   when: ansible_facts["pkg_mgr"] == "dnf5"
 
-- name: "Install package {{ dnf_automatic_package_name }}"
+- name: "Install dnf-automatic package"
   ansible.builtin.package:
     name: "{{ dnf_automatic_package_name }}"
     state: present
@@ -65,7 +65,7 @@
         - dnf-automatic-reboot.timer
       notify: Reload systemd
 
-- name: "Check status of {{ dnf_automatic_systemd_timer }}"
+- name: "Check status of systemd timer"
   ansible.builtin.systemd:
     name: "{{ dnf_automatic_systemd_timer }}"
   register: dnf_automatic_timer_status


### PR DESCRIPTION
The content of `dnf_automatic_systemd_timer` and `dnf_automatic_package_name` is dependant on the specific version of dnf installed on the host. But ansible only renders the task name globally (once) per task by targeting a host (seemingly at random?). The content of the names can be surprising in multi-os environments, and even lead to errors.

When running this role like this:

```
- name: Automatic upgrades
  hosts: all
  roles:
    - role: exploide.dnf-automatic
      when: ansible_facts['os_family'] == 'RedHat'
```

and targeting no RedHat based hosts (such as via -l) this leads to template errors:

```
[WARNING]: Encountered 1 template error.
error 1 - 'dnf_automatic_systemd_timer' is undefined
Origin: /home/fina/.ansible/roles/exploide.dnf-automatic/tasks/main.yml:68:9

66       notify: Reload systemd
67
68 - name: "Check status of {{ dnf_automatic_systemd_timer }}"
           ^ column 9
```

because ansible will still try to render each task in the role even though it is displayed as disabled for every host.

Additionally when running this role on dnf4 and dnf5 mixed environments the name is just random.