### PR TITLE
Implements support for integrated reboot option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ dnf_automatic_download_updates: true
 dnf_automatic_network_online_timeout: 60
 dnf_automatic_random_sleep: 0
 dnf_automatic_upgrade_type: security
+dnf_automatic_systemd_inhibit: true
+dnf_automatic_reboot: never
+dnf_automatic_reboot_command: "shutdown -r +5 'Rebooting after applying package updates'"
 dnf_automatic_emit_via: stdio
 dnf_automatic_system_name: "{{ ansible_facts['nodename'] }}"
 dnf_automatic_send_error_messages: false
@@ -37,10 +40,9 @@ This default configuration sets `dnf-automatic` up to automatically download and
 
 Note that the `dnf_automatic_base_overrides` dictionary can be used to override arbitrary preferences from the base dnf configuration file for `dnf-automatic`.
 
-In addition, `dnf_automatic_reboot` can be set to true to perform automatic reboots when installed updates require it:
+If the version of dnf-automatic installed is too old (lower than 4.14) to support the integrated reboot feature then a reboot timer can be installed instead. Its behaviour can be configured with the following variables when `dnf_automatic_reboot` is set to any value except `never`:
 
 ```yaml
-dnf_automatic_reboot: false
 dnf_automatic_reboot_dependencies: yum-utils
 dnf_automatic_reboot_OnCalendar: "03:00"
 dnf_automatic_reboot_AccuracySec: "15s"
@@ -48,6 +50,7 @@ dnf_automatic_reboot_Description: "dnf-automatic-reboot"
 dnf_automatic_reboot_ExecStart: "/bin/bash -c '/bin/needs-restarting -r || /sbin/reboot'"
 ```
 
+If the version of dnf-automatic does support the integrated reboot feature, these variables will be ignored and the values `dnf_automatic_reboot` and `dnf_automatic_reboot_command` will be used instead.
 
 ## Dependencies
 
@@ -66,14 +69,14 @@ This example playbook deploys `dnf-automatic` on all hosts but is configured suc
   - { role: exploide.dnf-automatic, dnf_automatic_upgrade_type: default }
 ```
 
-This example playbook deploys `dnf-automatic` to install security updates only, and deploys additional timer to reboot at 4:00 am when required:
+This example playbook deploys `dnf-automatic` to install security updates only and reboot when required. If the version of `dnf-automatic` is older than 4.14 it will deploy an additional timer to execute `dnf_automatic_reboot_ExecStart` instead of rebooting when updates are finished. The default value is equivalent to `when-needed`:
 
 ```yaml
 - name: Example playbook with auto reboot
   hosts: all
   remote_user: root
   roles:
-  - { role: exploide.dnf-automatic, dnf_automatic_reboot: true, dnf_automatic_reboot_OnCalendar: "04:00" }
+  - { role: exploide.dnf-automatic, dnf_automatic_reboot: when-needed, dnf_automatic_reboot_OnCalendar: "04:00" }
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ dnf_automatic_download_updates: true
 dnf_automatic_network_online_timeout: 60
 dnf_automatic_random_sleep: 0
 dnf_automatic_upgrade_type: security
+dnf_automatic_systemd_inhibit: true
+dnf_automatic_reboot: never
+dnf_automatic_reboot_command: "shutdown -r +5 'Rebooting after applying package updates'"
 
 # [emitters]
 
@@ -40,9 +43,8 @@ dnf_automatic_email_to: root
 # this dict can be used to override arbitrary settings from dnf.conf
 dnf_automatic_base_overrides: {}
 
-# Reboot
+# Reboot timer controls for older dnf-automatic
 
-dnf_automatic_reboot: false
 dnf_automatic_reboot_dependencies: yum-utils
 dnf_automatic_reboot_OnCalendar: "03:00"
 dnf_automatic_reboot_AccuracySec: "15s"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,13 @@
     name: "{{ dnf_automatic_package_name }}"
     state: present
 
+- name: Get package facts
+  ansible.builtin.package_facts:
+
+- name: Check if dnf-automatic version supports reboot.
+  ansible.builtin.set_fact:
+    dnf_automatic_supports_reboot: "{{ ansible_facts.packages[dnf_automatic_package_name][0].version is version('4.14.0', operator='>=', version_type='semver') }}"
+
 - name: Deploy dnf-automatic configuration file
   ansible.builtin.template:
     src: automatic.conf.j2
@@ -46,7 +53,7 @@
   when: dnf_automatic_timer_OnCalendar == "6:00"
 
 - name: Perform auto reboot specific tasks
-  when: dnf_automatic_reboot | bool
+  when: dnf_automatic_reboot != 'never' and not dnf_automatic_supports_reboot
   block:
     - name: Install dependencies needed for reboot
       ansible.builtin.package:
@@ -60,6 +67,18 @@
         owner: root
         group: root
         mode: "0644"
+      loop:
+        - dnf-automatic-reboot.service
+        - dnf-automatic-reboot.timer
+      notify: Reload systemd
+
+- name: Cleanup auto reboot specific tasks
+  when: dnf_automatic_supports_reboot
+  block:
+    - name: Remove service and timer units
+      ansible.builtin.file:
+        name: "/etc/systemd/system/{{ item }}"
+        state: absent
       loop:
         - dnf-automatic-reboot.service
         - dnf-automatic-reboot.timer
@@ -81,6 +100,7 @@
         dnf_automatic_timer_status.status["LoadState"] == "loaded"
 
 - name: Check status of dnf-automatic-reboot.timer
+  when: not dnf_automatic_supports_reboot
   ansible.builtin.systemd:
     name: dnf-automatic-reboot.timer
   register: dnf_automatic_reboot_timer
@@ -88,10 +108,11 @@
 - name: Set timer state for auto reboot
   ansible.builtin.systemd:
     name: dnf-automatic-reboot.timer
-    state: "{{ dnf_automatic_reboot | ternary('started', 'stopped') }}"
-    enabled: "{{ dnf_automatic_reboot }}"
+    state: '{{ "started" if (dnf_automatic_reboot != "never") else "stopped" }}'
+    enabled: '{{ dnf_automatic_reboot != "never" }}'
     masked: false
   # run always if not in check mode and the auto reboot is enabled
   # or if the timer unit exists regardless of the check mode state
-  when: (not ansible_check_mode and dnf_automatic_reboot) or
-        dnf_automatic_reboot_timer.status["LoadState"] == "loaded"
+  when: (not ansible_check_mode or
+        dnf_automatic_reboot_timer.status["LoadState"] == "loaded") and
+        not dnf_automatic_supports_reboot

--- a/templates/automatic.conf.j2
+++ b/templates/automatic.conf.j2
@@ -10,6 +10,11 @@ download_updates = {{ dnf_automatic_download_updates }}
 network_online_timeout = {{ dnf_automatic_network_online_timeout }}
 random_sleep = {{ dnf_automatic_random_sleep }}
 upgrade_type = {{ dnf_automatic_upgrade_type }}
+systemd_inhibit = {{ dnf_automatic_systemd_inhibit }}
+{% if dnf_automatic_supports_reboot %}
+reboot = {{ dnf_automatic_reboot }}
+reboot_command = {{ dnf_automatic_reboot_command }}
+{% endif %}
 
 [emitters]
 


### PR DESCRIPTION
Adds support for using the internal reboot feature when available. From testing this appears to be from 4.14 present in Redhat Enterprise 9 so this is the version tested for.

If an earlier version is detected and reboot as wanted it falls back to using the timer as it did previously.